### PR TITLE
Convert say command to swift for singing

### DIFF
--- a/SingX/AppDelegate.applescript
+++ b/SingX/AppDelegate.applescript
@@ -9186,11 +9186,9 @@ end if
       set allnotesFile to (path to temporary items as string) & "allnotes_temp.txt"
       set jsonFile to "SingX/notes.json"
       
-      -- allnotesを一時ファイルに保存
+      -- allnotesを一時ファイルに保存（echoコマンドを使用）
       try
-          set fileRef to open for access file allnotesFile with write permission
-          write allnotes to fileRef
-          close access fileRef
+          do shell script "echo " & quoted form of (allnotes as string) & " > " & quoted form of allnotesFile
           
           -- PythonスクリプトでJSONに変換
           do shell script "python3 SingX/parse_notes.py " & quoted form of allnotesFile & " " & quoted form of jsonFile

--- a/SingX/AppDelegate.applescript
+++ b/SingX/AppDelegate.applescript
@@ -9183,18 +9183,20 @@ end if
             end if
             else
       -- allnotesをJSONに変換してSingX/notes.jsonに保存する処理
-      set allnotesFile to (path to temporary items as string) & "allnotes_temp.txt"
-      set jsonFile to "SingX/notes.json"
+      set appPath to (path to me as string)
+      set appDir to do shell script "dirname " & quoted form of appPath
+      set allnotesFile to appDir & "/allnotes_temp.txt"
+      set jsonFile to appDir & "/notes.json"
       
       -- allnotesを一時ファイルに保存（echoコマンドを使用）
       try
           do shell script "echo " & quoted form of (allnotes as string) & " > " & quoted form of allnotesFile
           
           -- PythonスクリプトでJSONに変換
-          do shell script "python3 SingX/parse_notes.py " & quoted form of allnotesFile & " " & quoted form of jsonFile
+          do shell script "python3 " & quoted form of (appDir & "/parse_notes.py") & " " & quoted form of allnotesFile & " " & quoted form of jsonFile
           
           -- Swiftスクリプトで音声再生
-          do shell script "swift SingX/sing.swift " & quoted form of jsonFile
+          do shell script "swift " & quoted form of (appDir & "/sing.swift") & " " & quoted form of jsonFile
           
       on error errMsg
           display alert "Error processing notes: " & errMsg

--- a/SingX/AppDelegate.applescript
+++ b/SingX/AppDelegate.applescript
@@ -9188,9 +9188,12 @@ end if
       set allnotesFile to appDir & "/allnotes_temp.txt"
       set jsonFile to appDir & "/notes.json"
       
-      -- allnotesを一時ファイルに保存（echoコマンドを使用）
+      -- allnotesを一時ファイルに保存（AppleScriptのファイル操作を使用）
       try
-          do shell script "echo " & quoted form of (allnotes as string) & " > " & quoted form of allnotesFile
+          set allnotesStr to allnotes as string
+          set fileRef to open for access file allnotesFile with write permission
+          write allnotesStr to fileRef
+          close access fileRef
           
           -- PythonスクリプトでJSONに変換
           do shell script "python3 " & quoted form of (appDir & "/parse_notes.py") & " " & quoted form of allnotesFile & " " & quoted form of jsonFile

--- a/SingX/AppDelegate.applescript
+++ b/SingX/AppDelegate.applescript
@@ -9190,7 +9190,8 @@ end if
       
       -- allnotesを一時ファイルに保存（AppleScriptのファイル操作を使用）
       try
-          set allnotesStr to allnotes as string
+          -- allnotesを直接文字列として取得し直す
+          set allnotesStr to (editorWindow's |string|()) as string
           set fileRef to open for access file allnotesFile with write permission
           write allnotesStr to fileRef
           close access fileRef

--- a/SingX/AppDelegate.applescript
+++ b/SingX/AppDelegate.applescript
@@ -9182,9 +9182,27 @@ end if
                 else
             end if
             else
-      -- allnotesをJSONに変換してSingX/notes.jsonに保存する処理（仮）
-      -- ここは後で自動化スクリプトを用意します
-      do shell script "swift SingX/sing.swift SingX/notes.json"
+      -- allnotesをJSONに変換してSingX/notes.jsonに保存する処理
+      set allnotesFile to (path to temporary items as string) & "allnotes_temp.txt"
+      set jsonFile to "SingX/notes.json"
+      
+      -- allnotesを一時ファイルに保存
+      try
+          set fileRef to open for access file allnotesFile with write permission
+          write allnotes to fileRef
+          close access fileRef
+          
+          -- PythonスクリプトでJSONに変換
+          do shell script "python3 SingX/parse_notes.py " & quoted form of allnotesFile & " " & quoted form of jsonFile
+          
+          -- Swiftスクリプトで音声再生
+          do shell script "swift SingX/sing.swift " & quoted form of jsonFile
+          
+      on error errMsg
+          display alert "Error processing notes: " & errMsg
+          set messg to "Error processing notes..."
+          previewWindow's setStringValue_(messg)
+      end try
       end if
       
       on error errorMessage number errorNumber
@@ -9198,7 +9216,7 @@ end if
       end if
 
       try
-          do shell script "killall say"
+          do shell script "killall swift"
           on error
           
       end try

--- a/SingX/AppDelegate.applescript
+++ b/SingX/AppDelegate.applescript
@@ -9182,7 +9182,9 @@ end if
                 else
             end if
             else
-      do shell script "say" & voiceNameStr & wdhead & allnotes & " &>/dev/null &"
+      -- allnotesをJSONに変換してSingX/notes.jsonに保存する処理（仮）
+      -- ここは後で自動化スクリプトを用意します
+      do shell script "swift SingX/sing.swift SingX/notes.json"
       end if
       
       on error errorMessage number errorNumber

--- a/SingX/parse_notes.py
+++ b/SingX/parse_notes.py
@@ -6,34 +6,56 @@ import sys
 def parse_notes(text):
     """allnotesテキストをパースしてJSONに変換"""
     notes = []
-    pattern = r'\[\[pbas (\d+)\]\] \[\[rate (\d+)\]\] \[\[pmod (\d+)\]\] \[\[volm ([\d.]+)\]\] (.+?)(?: \[\[slnc (\d+)\]\]|$)'
-    matches = re.findall(pattern, text, re.DOTALL)
-    for match in matches:
-        pbas, rate, pmod, volm, note_text, slnc = match
-        pitch = float(pbas)
-        pitch_normalized = 0.5 + (pitch - 57) / (66 - 57) * (2.0 - 0.5)
-        pitch_normalized = max(0.5, min(2.0, pitch_normalized))
-        rate_normalized = float(rate) / 200.0
-        rate_normalized = max(0.0, min(1.0, rate_normalized))
-        note = {
-            "text": note_text.strip(),
-            "pitch": round(pitch_normalized, 3),
-            "rate": round(rate_normalized, 3),
-            "volume": float(volm),
-            "pause": float(slnc) / 1000.0 if slnc else None
-        }
-        notes.append(note)
+    
+    # 行ごとに分割して処理
+    lines = text.strip().split('\n')
+    
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+            
+        # 正規表現でパラメータとテキストを抽出
+        pattern = r'\[\[pbas (\d+)\]\] \[\[rate (\d+)\]\] \[\[pmod (\d+)\]\] \[\[volm ([\d.]+)\]\] (.+?)(?: \[\[slnc (\d+)\]\]|$)'
+        
+        match = re.search(pattern, line)
+        if match:
+            pbas, rate, pmod, volm, note_text, slnc = match.groups()
+            
+            # ピッチを0.5〜2.0の範囲に正規化（57〜66を基準）
+            pitch = float(pbas)
+            pitch_normalized = 0.5 + (pitch - 57) / (66 - 57) * (2.0 - 0.5)
+            pitch_normalized = max(0.5, min(2.0, pitch_normalized))
+            
+            # レートを0.0〜1.0の範囲に正規化（仮に200を基準）
+            rate_normalized = float(rate) / 200.0
+            rate_normalized = max(0.0, min(1.0, rate_normalized))
+            
+            note = {
+                "text": note_text.strip(),
+                "pitch": round(pitch_normalized, 3),
+                "rate": round(rate_normalized, 3),
+                "volume": float(volm),
+                "pause": float(slnc) / 1000.0 if slnc else None  # msを秒に変換
+            }
+            notes.append(note)
+    
     return notes
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: python3 parse_notes.py <input_text_file> <output_json_file>")
         sys.exit(1)
+    
     input_file = sys.argv[1]
     output_file = sys.argv[2]
-    with open(input_file, "r", encoding="utf-8") as f:
+    
+    with open(input_file, 'r', encoding='utf-8') as f:
         text = f.read()
+    
     notes = parse_notes(text)
-    with open(output_file, "w", encoding="utf-8") as f:
+    
+    with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(notes, f, indent=2, ensure_ascii=False)
+    
     print(f"Parsed {len(notes)} notes to {output_file}")

--- a/SingX/parse_notes.py
+++ b/SingX/parse_notes.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import re
+import json
+import sys
+
+def parse_notes(text):
+    """allnotesテキストをパースしてJSONに変換"""
+    notes = []
+    pattern = r'\[\[pbas (\d+)\]\] \[\[rate (\d+)\]\] \[\[pmod (\d+)\]\] \[\[volm ([\d.]+)\]\] (.+?)(?: \[\[slnc (\d+)\]\]|$)'
+    matches = re.findall(pattern, text, re.DOTALL)
+    for match in matches:
+        pbas, rate, pmod, volm, note_text, slnc = match
+        pitch = float(pbas)
+        pitch_normalized = 0.5 + (pitch - 57) / (66 - 57) * (2.0 - 0.5)
+        pitch_normalized = max(0.5, min(2.0, pitch_normalized))
+        rate_normalized = float(rate) / 200.0
+        rate_normalized = max(0.0, min(1.0, rate_normalized))
+        note = {
+            "text": note_text.strip(),
+            "pitch": round(pitch_normalized, 3),
+            "rate": round(rate_normalized, 3),
+            "volume": float(volm),
+            "pause": float(slnc) / 1000.0 if slnc else None
+        }
+        notes.append(note)
+    return notes
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python3 parse_notes.py <input_text_file> <output_json_file>")
+        sys.exit(1)
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+    with open(input_file, "r", encoding="utf-8") as f:
+        text = f.read()
+    notes = parse_notes(text)
+    with open(output_file, "w", encoding="utf-8") as f:
+        json.dump(notes, f, indent=2, ensure_ascii=False)
+    print(f"Parsed {len(notes)} notes to {output_file}")

--- a/SingX/sing.swift
+++ b/SingX/sing.swift
@@ -1,0 +1,45 @@
+import Foundation
+import AVFoundation
+
+// コマンドライン引数でJSONファイルパスを受け取る
+// 例: swift sing.swift /path/to/notes.json
+
+guard CommandLine.arguments.count > 1 else {
+    print("Usage: sing.swift <json_file>")
+    exit(1)
+}
+
+let jsonPath = CommandLine.arguments[1]
+let url = URL(fileURLWithPath: jsonPath)
+
+guard let data = try? Data(contentsOf: url) else {
+    print("Failed to read JSON file")
+    exit(1)
+}
+
+struct Note: Codable {
+    let text: String
+    let pitch: Float? // 0.5〜2.0
+    let rate: Float?  // 0.0〜1.0
+    let volume: Float? // 0.0〜1.0
+    let pause: Double? // ms単位
+}
+
+guard let notes = try? JSONDecoder().decode([Note].self, from: data) else {
+    print("Invalid JSON format")
+    exit(1)
+}
+
+let synthesizer = AVSpeechSynthesizer()
+for note in notes {
+    let utterance = AVSpeechUtterance(string: note.text)
+    utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+    if let pitch = note.pitch { utterance.pitchMultiplier = pitch }
+    if let rate = note.rate { utterance.rate = rate }
+    if let volume = note.volume { utterance.volume = volume }
+    synthesizer.speak(utterance)
+    while synthesizer.isSpeaking { RunLoop.current.run(until: Date().addingTimeInterval(0.05)) }
+    if let pause = note.pause, pause > 0 {
+        Thread.sleep(forTimeInterval: pause / 1000.0)
+    }
+}

--- a/SingX/test_notes.txt
+++ b/SingX/test_notes.txt
@@ -1,0 +1,8 @@
+[[pbas 57]] [[rate 132]] [[pmod 1]] [[volm 1.0]] URNS 
+[[pbas 64]] [[rate 151]] [[pmod 1]] [[volm 1.0]] and 
+[[pbas 64]] [[rate 117]] [[pmod 3]] [[volm 1.0]] odours 
+[[pbas 64]] [[rate 93]] [[pmod 0]] [[volm 1.0]] bring [[slnc 400]]
+[[pbas 57]] [[rate 170]] [[pmod 1]] [[volm 1.0]] away 
+[[pbas 66]] [[rate 126]] [[pmod 0]] [[volm 1.0]] Vapours 
+[[pbas 62]] [[rate 172]] [[pmod 0]] [[volm 1.0]] sighs 
+[[pbas 57]] [[rate 169]] [[pmod 3]] [[volm 1.0]] darken [[slnc 400]]

--- a/SingX/test_output.json
+++ b/SingX/test_output.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "URNS",
+    "pitch": 0.5,
+    "rate": 0.66,
+    "volume": 1.0,
+    "pause": null
+  },
+  {
+    "text": "and",
+    "pitch": 1.667,
+    "rate": 0.755,
+    "volume": 1.0,
+    "pause": null
+  },
+  {
+    "text": "odours",
+    "pitch": 1.667,
+    "rate": 0.585,
+    "volume": 1.0,
+    "pause": null
+  },
+  {
+    "text": "bring",
+    "pitch": 1.667,
+    "rate": 0.465,
+    "volume": 1.0,
+    "pause": 0.4
+  },
+  {
+    "text": "away",
+    "pitch": 0.5,
+    "rate": 0.85,
+    "volume": 1.0,
+    "pause": null
+  },
+  {
+    "text": "Vapours",
+    "pitch": 2.0,
+    "rate": 0.63,
+    "volume": 1.0,
+    "pause": null
+  },
+  {
+    "text": "sighs",
+    "pitch": 1.333,
+    "rate": 0.86,
+    "volume": 1.0,
+    "pause": null
+  },
+  {
+    "text": "darken",
+    "pitch": 0.5,
+    "rate": 0.845,
+    "volume": 1.0,
+    "pause": 0.4
+  }
+]


### PR DESCRIPTION
Add `sing.swift` to enable pitch-controlled speech synthesis using `AVSpeechSynthesizer` as a replacement for the `say` command.

---
<a href="https://cursor.com/background-agent?bcId=bc-290eafad-4250-4139-bd32-f9dad7709eb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-290eafad-4250-4139-bd32-f9dad7709eb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>